### PR TITLE
Fix - Play prompt block error with ssml

### DIFF
--- a/src/contactFlow.ts
+++ b/src/contactFlow.ts
@@ -130,7 +130,7 @@ export const jsonToContactFlow = (lambdaFunction: Function) => {
       },
       {
         Parameters: {
-          SSML: "Your original calling number is <say-as interpret-as='telephone'>$.Attributes.OriginalCallingNumber</say-as>",
+          SSML: "<speak>Your original calling number is <say-as interpret-as='telephone'>$.Attributes.OriginalCallingNumber</say-as></speak>",
         },
         Identifier: 'PlayOriginalCallingNumber',
         Type: 'MessageParticipant',


### PR DESCRIPTION
Fixes # Play prompt with SSML
```
{
    "Results": "Error",
    "ContactId": "a57f531b-c238-487a-b13a-49a60f2f951c",
    "ContactFlowId": "arn:aws:connect:us-east-1:905418326942:instance/c7213845-ec16-47ba-90f9-082f59ff9ac2/contact-flow/dd00b2eb-a5d8-451f-bb8d-0c6b14271292",
    "ContactFlowName": "TakeBackAndTransferDemo",
    "ContactFlowModuleType": "PlayPrompt",
    "Identifier": "PlayOriginalCallingNumber",
    "Timestamp": "2024-08-06T20:19:48.317Z"
}
```